### PR TITLE
Signal Status: Support New "kits" Socratautil Source

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ atd-jobs-util
 atd-kits-util
 atd-knack-util
 atd-log-util
-atd-socrata-util-dev==0.0.5
+atd-socrata-util
 bs4
 dropbox
 feedparser==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ atd-jobs-util
 atd-kits-util
 atd-knack-util
 atd-log-util
-atd-socrata-util
+atd-socrata-util-dev==0.0.5
 bs4
 dropbox
 feedparser==5.2.1

--- a/transportation-data-publishing/open_data/sig_stat_pub.py
+++ b/transportation-data-publishing/open_data/sig_stat_pub.py
@@ -76,7 +76,7 @@ def main():
         TYPE: Description
     """
     # get current traffic signal data from Socrata
-    socr = socratautil.Soda(resource=SOCR_SIG_RES_ID, fetch_metadata=True)
+    socr = socratautil.Soda(resource=SOCR_SIG_RES_ID)
     signal_data = socr.data
 
     kits_query = kitsutil.status_query()
@@ -112,7 +112,7 @@ def main():
         new_data = []
 
     #  get current signal status DATASET and metadata from socrata
-    sig_status = socratautil.Soda(resource=SOCR_SIG_STAT_RES_ID, fetch_metadata=True)
+    sig_status = socratautil.Soda(resource=SOCR_SIG_STAT_RES_ID)
 
     #  add special socrata deleted field
     #  required for sending delete requests to socrata

--- a/transportation-data-publishing/open_data/sig_stat_pub.py
+++ b/transportation-data-publishing/open_data/sig_stat_pub.py
@@ -158,6 +158,7 @@ def main():
             lon_field="location_longitude",
             location_field="location",
             replace=False,
+            source="kits"
         )
 
         return len(payload)


### PR DESCRIPTION
Fixes #230 

The socratautil was throwing a `ValueError` when trying to convert datetimes for this script, with source data coming from KITS. Turns out we this script is now passing in ISO datestrings instead of mills. I tried really hard to understand why we're no longer passing in millisecond timestamps. I thought it might be an issue related to a new release of Arrow, but rolling back to `0.12.0` and `0.10.0` did not fix the issue. I also consider a KITS DB schema change, but we're receiving `datetime` objects like always. So it remains a mystery. To fix this, we've added support for a new `source=kits` parameter in the `Soda` class, which will handle the input dates as ISO strings.