### PR TITLE
Point Markings Work Order Publisher to New App

### DIFF
--- a/transportation-data-publishing/config/knack/config.py
+++ b/transportation-data-publishing/config/knack/config.py
@@ -15,9 +15,9 @@ cfg = {
             "object_138",  # admin_object_meta
             "object_95",  # csr_flex_notes
             "object_67",  # quote_of_the_week
-            "object_77",  # signal_id_generator
+            "object_1867",  # signal_id_generator
             "object_148",  # street_names
-            "object_7",  # street_segments
+            "object_186",  # street_segments
             "object_83",  # tmc_issues
             "object_58",  # tmc_issues_DEPRECTATED_HISTORICAL_DATA_ONLY
             "object_10",  # Asset editor
@@ -27,7 +27,7 @@ cfg = {
             "object_57",  # Supervisor | AMD
             "object_65",  # Technician|AMD
             "object_68",  # Quote of the Week Editor
-            "object_76",  # Inventory Editor
+            "object_1866",  # Inventory Editor
             "object_97",  # Account Administrator
             "object_151",  # Supervisor | Signs&Markings
             "object_152",  # Technician | Signs & Markings
@@ -388,9 +388,9 @@ cfg = {
         "modified_date_field": "MODIFIED_DATE",
         "modified_date_field_id": "field_2150",
         "obj": None,
-        "scene": "scene_774",
+        "scene": "scene_1249",
         "view": "view_2226",
-        "ref_obj": ["object_140", "object_11", "object_7"],
+        "ref_obj": ["object_140", "object_11", "object_186"],
         "socrata_resource_id": "",
         "pub_log_id": "",
         "status_field": "WORK_ORDER_STATUS",
@@ -484,34 +484,31 @@ MARKINGS_AGOL = [
     # Order of config elements matters! Work orders must be processed before
     # jobs and attachments because work orders are the parent record to both.
     {
-        "name": "signs_markings_work_orders",
-        "scene": "scene_774",
-        "view": "view_2226",
-        "ref_obj": ["object_140", "object_7"],
+        "name": "markings_work_orders",
+        "scene": "scene_1249",
+        "view": "view_3099",
+        "ref_obj": ["object_140", "object_186"],
         "modified_date_field_id": "field_2150",
         "modified_date_field": "MODIFIED_DATE",
         "geometry_service_id": "a78db5b7a72640bcbb181dcb88817652",  #  street segments
         "geometry_layer_id": 0,
         "geometry_record_id_field": "SEGMENT_ID",
         "geometry_layer_spatial_ref": 102739,
-        "multi_source_geometry": True,
         "primary_key": "ATD_WORK_ORDER_ID",
         "service_id": "a9f5be763a67442a98f684935d15729b",
         "layer_id": 1,
         "item_type": "layer",
     },
     {
-        "name": "signs_markings_jobs",
-        "scene": "scene_774",
-        "view": "view_2033",
-        "ref_obj": ["object_141", "object_7"],
+        "name": "markings_jobs",
+        "scene": "scene_1249",
+        "view": "view_3100",
+        "ref_obj": ["object_141", "object_186"],
         "modified_date_field_id": "field_2196",
         "modified_date_field": "MODIFIED_DATE",
-        "geometry_service_id": "a9f5be763a67442a98f684935d15729b",  #  work orders
-        "geometry_layer_id": 1,
+        "geometry_service_id": "internal",  # geometry is pulled from work order data in-memory
         "geometry_record_id_field": "ATD_WORK_ORDER_ID",
         "geometry_layer_spatial_ref": 102739,
-        "multi_source_geometry": False,
         "primary_key": "ATD_SAM_JOB_ID",
         "service_id": "a9f5be763a67442a98f684935d15729b",
         "layer_id": 0,
@@ -519,8 +516,8 @@ MARKINGS_AGOL = [
     },
     {
         "name": "attachments",
-        "scene": "scene_774",
-        "view": "view_2227",
+        "scene": "scene_1249",
+        "view": "view_3096",
         "ref_obj": ["object_153"],
         "modified_date_field_id": "field_2407",
         "modified_date_field": "CREATED_DATE",
@@ -532,9 +529,9 @@ MARKINGS_AGOL = [
         "extract_attachment_url": True,
     },
     {
-        "name": ",specifications",
-        "scene": "scene_774",
-        "view": "view_2272",
+        "name": "specifications",
+        "scene": "scene_1249",
+        "view": "view_3103",
         "ref_obj": ["object_143", "object_140", "object_141"],
         "modified_date_field_id": "field_2567",
         "modified_date_field": "MODIFIED_DATE",
@@ -544,9 +541,9 @@ MARKINGS_AGOL = [
         "item_type": "table",
     },
     {
-        "name": ",materials",
-        "scene": "scene_774",
-        "view": "view_2273",
+        "name": "materials",
+        "scene": "scene_1249",
+        "view": "view_3104",
         "ref_obj": ["object_36", "object_140", "object_141", "object_15"],
         "modified_date_field_id": "field_771",
         "modified_date_field": "MODIFIED_DATE",
@@ -598,7 +595,7 @@ STREET_SEG_UPDATER = {
     "modified_date_field_id": "field_144",
     "modified_date_field": "MODIFIED_DATE",
     "primary_key": "SEGMENT_ID_NUMBER",
-    "ref_obj": ["object_7"],
+    "ref_obj": ["object_186"],
     "scene": "scene_424",
     "view": "view_1198",
 }

--- a/transportation-data-publishing/data_tracker/markings_agol.py
+++ b/transportation-data-publishing/data_tracker/markings_agol.py
@@ -1,19 +1,34 @@
 # Publish pavement markings work orders to ArcGIS Online
+import copy
 import pdb
 import traceback
 
+import agolutil
+import argutil
 import arrow
+import datautil
+import emailutil
+import knackutil
 import knackpy
 
 import _setpath
 from config.secrets import *
 from config.knack.config import MARKINGS_AGOL as config
 
-import agolutil
-import argutil
-import datautil
-import knackutil
 
+# we use this global to store wo geometries so they can be accessed
+# when fetching geometries for jobs. it aint pretty, but is it really so bad?
+work_order_geometries = None
+
+def get_paths_from_work_orders(records, match_field="ATD_WORK_ORDER_ID", output_field="paths"):
+    # copy work order geometries from work order to child jobs
+    for record in records:
+        for wo in work_order_geometries:    
+            if record[match_field] == wo[match_field]:
+                record[output_field] = wo[output_field]
+                continue
+
+    return records
 
 def remove_empty_strings(records):
     new_records = []
@@ -125,7 +140,7 @@ def knackpy_wrapper(cfg, auth, obj=None, filters=None):
         app_id=auth["app_id"],
         api_key=auth["api_key"],
         filters=filters,
-        page_limit=10000,
+        page_limit=1000000
     )
 
 
@@ -166,6 +181,7 @@ def main():
     we receive it.
     """
     for cfg in config:
+        print(cfg["name"])
         filters = knackutil.date_filter_on_or_after(
             last_run_date, cfg["modified_date_field_id"]
         )
@@ -186,22 +202,15 @@ def main():
 
         records = kn.data
 
-        if cfg.get("geometry_service_id"):
-            #  dataset has geomteries to be retrieved from another dataset
-            if cfg.get("multi_source_geometry"):
-                source_ids = datautil.unique_from_list_field(
-                    records, list_field=cfg["geometry_record_id_field"]
-                )
+        if cfg.get("name") == "markings_work_orders":
+            #  markings work order geometries are retrieved from AGOL
+            
+            # reduce to unique segment ids from all records
+            segment_ids = datautil.unique_from_list_field(
+                records, list_field=cfg["geometry_record_id_field"]
+            )
 
-            else:
-                source_ids = datautil.get_values(
-                    records, cfg["geometry_record_id_field"]
-                )
-
-            where_ids = ", ".join(f"'{x}'" for x in source_ids)
-
-            if where_ids:
-                where = "{} in ({})".format(cfg["geometry_record_id_field"], where_ids)
+            if segment_ids:
 
                 geometry_layer = agolutil.get_item(
                     auth=AGOL_CREDENTIALS,
@@ -209,20 +218,43 @@ def main():
                     layer_id=cfg["geometry_layer_id"],
                 )
 
-                source_geometries = geometry_layer.query(
-                    where=where, outFields=cfg["geometry_record_id_field"]
-                )
+                source_geometries_all = []
 
-                if not source_geometries:
-                    raise Exception(
-                        "No features returned from source geometry layer query"
-                    )
+                chunksize = 200
 
+                for i in range(0, len(segment_ids), chunksize):
+                    # fetch agol source geometries in chunks
+
+                    print(f"Chunk {i}-{i+chunksize}")
+                    where_ids = ", ".join(f"'{x}'" for x in segment_ids[i : i + chunksize])
+
+                    if where_ids:
+                        where = "{} in ({})".format(cfg["geometry_record_id_field"], where_ids)
+
+                        source_geometries_chunk = geometry_layer.query(
+                            where=where, outFields=cfg["geometry_record_id_field"]
+                        )
+
+                        if not source_geometries_chunk:
+                            raise Exception(
+                                "No features returned from source geometry layer query"
+                            )
+
+                        source_geometries_all.extend(source_geometries_chunk)
+                
                 records = append_paths(
                     kn.data,
-                    source_geometries,
+                    source_geometries_all,
                     path_id_field=cfg["geometry_record_id_field"],
                 )
+
+                global work_order_geometries
+                work_order_geometries = copy.deepcopy(records)
+
+
+        elif cfg.get("name") == "markings_jobs":
+            # get data from markings records
+            records = get_paths_from_work_orders(records)
 
         if cfg.get("extract_attachment_url"):
             records = knackutil.attachment_url(
@@ -237,7 +269,7 @@ def main():
             layer_id=cfg["layer_id"],
             item_type=cfg["item_type"],
         )
-
+        
         if args.replace:
             res = update_layer.delete_features(where="1=1")
             agolutil.handle_response(res)
@@ -260,6 +292,7 @@ def main():
             agolutil.handle_response(res)
 
         for i in range(0, len(records), 1000):
+            # insert agol features in chunks
             adds = agolutil.feature_collection(
                 records[i : i + 1000], spatial_ref=102739
             )


### PR DESCRIPTION
Fixes [this issue](https://github.com/cityofaustin/atd-data-tech/issues/343) in `atd-data-tech`.

Updates the publisher config to point to the new app, and also now fetches markings job geometries from the markings work orders. This reduces our AGOL calls by 50%.