### PR TITLE
Publish Signs Work Orders to AGOL

### DIFF
--- a/transportation-data-publishing/config/knack/config.py
+++ b/transportation-data-publishing/config/knack/config.py
@@ -562,6 +562,18 @@ SIGNS_AGOL = [
     # Order of config elements matters! Work orders must be processed before
     # speccs, materials, etc because work orders are the parent record.
     {
+        "name": "work_orders_signs",
+        "scene": "scene_1249",
+        "view": "view_3107",
+        "ref_obj": ["object_176"],
+        "modified_date_field_id": "field_3206",
+        "modified_date_field": "MODIFIED_DATE",
+        "primary_key": "ATD_WORK_ORDER_ID",
+        "service_id": "8e97ddf6f9bd4d26a7486b7ee40f7cce",
+        "layer_id": 2,  # note that this service id is actually 3, but this identifies the table #. not sure where this is exposed or documented. trial and error...
+        "item_type": "table",
+    },
+    {
         # there is no AGOL feature service for sign locations, instead
         # we merge location attributes to each work_orders_signs_asset_spec_actuals
         "name": "work_order_signs_locations",
@@ -571,8 +583,8 @@ SIGNS_AGOL = [
         "modified_date_field_id": "field_3383",
         "modified_date_field": "MODIFIED_DATE",
         "primary_key": "LOCATION_ID",
-        "geometry_field_name" : "SIGNS_LOCATION",
-        "service_id": None, 
+        "geometry_field_name": "SIGNS_LOCATION",
+        "service_id": None,
         "layer_id": None,
         "item_type": None,
     },
@@ -583,14 +595,15 @@ SIGNS_AGOL = [
         "ref_obj": ["object_181", "object_178", "object_177"],
         "modified_date_field_id": "field_3365",
         "modified_date_field": "MODIFIED_DATE",
-        "location_join_field" : "LOCATION_ID",
-        "work_order_id_field" : "ATD_WORK_ORDER_ID",
+        "location_join_field": "LOCATION_ID",
+        "work_order_id_field": "ATD_WORK_ORDER_ID",
         "primary_key": "SPECIFICATION_ID",
         "service_id": "8e97ddf6f9bd4d26a7486b7ee40f7cce",
         "layer_id": 0,
         "item_type": "layer",
-    }
+    },
 ]
+
 
 SECONDARY_SIGNALS_UPDATER = {
     "update_field": "field_1329",

--- a/transportation-data-publishing/config/knack/config.py
+++ b/transportation-data-publishing/config/knack/config.py
@@ -557,11 +557,12 @@ MARKINGS_AGOL = [
     },
 ]
 
-SIGNS_AGOL = [
+SIGNS_AGOL = {
     # Knack and AGOL source object defintions.
     # Order of config elements matters! Work orders must be processed before
     # speccs, materials, etc because work orders are the parent record.
-    {
+    
+    "work_order_signs_locations" : {
         # there is no AGOL feature service for sign locations, instead
         # we merge location attributes to each work_orders_signs_asset_spec_actuals
         "name": "work_order_signs_locations",
@@ -576,7 +577,7 @@ SIGNS_AGOL = [
         "layer_id": None,
         "item_type": None,
     },
-    {
+    "work_orders_signs" : {
         "name": "work_orders_signs",
         "scene": "scene_1249",
         "view": "view_3107",
@@ -588,7 +589,7 @@ SIGNS_AGOL = [
         "layer_id": 2,  # note that this service id is actually 3, but this identifies the table #. not sure where this is exposed or documented. trial and error...
         "item_type": "layer",
     },
-    {
+    "work_orders_signs_asset_spec_actuals" : {
         "name": "work_orders_signs_asset_spec_actuals",
         "scene": "scene_1249",
         "view": "view_3106",
@@ -602,7 +603,7 @@ SIGNS_AGOL = [
         "layer_id": 0,
         "item_type": "layer",
     },
-]
+}
 
 
 SECONDARY_SIGNALS_UPDATER = {

--- a/transportation-data-publishing/config/knack/config.py
+++ b/transportation-data-publishing/config/knack/config.py
@@ -561,8 +561,7 @@ SIGNS_AGOL = {
     # Knack and AGOL source object defintions.
     # Order of config elements matters! Work orders must be processed before
     # speccs, materials, etc because work orders are the parent record.
-    
-    "work_order_signs_locations" : {
+    "work_order_signs_locations": {
         # there is no AGOL feature service for sign locations, instead
         # we merge location attributes to each work_orders_signs_asset_spec_actuals
         "name": "work_order_signs_locations",
@@ -577,7 +576,7 @@ SIGNS_AGOL = {
         "layer_id": None,
         "item_type": None,
     },
-    "work_orders_signs" : {
+    "work_orders_signs": {
         "name": "work_orders_signs",
         "scene": "scene_1249",
         "view": "view_3107",
@@ -585,11 +584,11 @@ SIGNS_AGOL = {
         "modified_date_field_id": "field_3206",
         "modified_date_field": "MODIFIED_DATE",
         "primary_key": "ATD_WORK_ORDER_ID",
-        "service_id": "8e97ddf6f9bd4d26a7486b7ee40f7cce",
-        "layer_id": 1,  # note that this service id is actually 3, but this identifies the table #. not sure where this is exposed or documented. trial and error...
+        "service_id": "93e29b23c39b4110ab0bbefde79b4063",
+        "layer_id": 1,
         "item_type": "layer",
     },
-    "work_orders_signs_asset_spec_actuals" : {
+    "work_orders_signs_asset_spec_actuals": {
         "name": "work_orders_signs_asset_spec_actuals",
         "scene": "scene_1249",
         "view": "view_3106",
@@ -599,9 +598,36 @@ SIGNS_AGOL = {
         "location_join_field": "LOCATION_ID",
         "work_order_id_field": "ATD_WORK_ORDER_ID",
         "primary_key": "SPECIFICATION_ID",
-        "service_id": "8e97ddf6f9bd4d26a7486b7ee40f7cce",
+        "service_id": "93e29b23c39b4110ab0bbefde79b4063",
         "layer_id": 0,
         "item_type": "layer",
+    },
+    "work_orders_attachments": {
+        "name": "work_orders_attachments",
+        "scene": "scene_1249",
+        "view": "view_3127",
+        "ref_obj": ["object_153"],
+        "modified_date_field_id": "object_153",
+        "modified_date_field": "MODIFIED_DATE",
+        "work_order_id_field": "ATD_WORK_ORDER_ID",
+        "primary_key": "ATTACHMENT_ID",
+        "service_id": "93e29b23c39b4110ab0bbefde79b4063",
+        "layer_id": 0,
+        "item_type": "table",
+        "extract_attachment_url": True,
+    },
+    "work_orders_materials": {
+        "name": "work_orders_materials",
+        "scene": "scene_1249",
+        "view": "view_3126",
+        "ref_obj": ["object_36", "object_176"],
+        "modified_date_field_id": "field_771",
+        "modified_date_field": "MODIFIED_DATE",
+        "work_order_id_field": "ATD_WORK_ORDER_ID",
+        "primary_key": "TRANSACTION_ID",
+        "service_id": "93e29b23c39b4110ab0bbefde79b4063",
+        "layer_id": 1,  # note that this service id is actually 3, but this identifies the table #. not sure where this is exposed or documented. trial and error...
+        "item_type": "table",
     },
 }
 

--- a/transportation-data-publishing/config/knack/config.py
+++ b/transportation-data-publishing/config/knack/config.py
@@ -580,12 +580,14 @@ SIGNS_AGOL = [
         "name": "work_orders_signs_asset_spec_actuals",
         "scene": "scene_1249",
         "view": "view_3106",
-        "ref_obj": ["object_181", "object_178"],
+        "ref_obj": ["object_181", "object_178", "object_177"],
         "modified_date_field_id": "field_3365",
         "modified_date_field": "MODIFIED_DATE",
+        "location_join_field" : "LOCATION_ID",
+        "work_order_id_field" : "ATD_WORK_ORDER_ID",
         "primary_key": "SPECIFICATION_ID",
         "service_id": "8e97ddf6f9bd4d26a7486b7ee40f7cce",
-        "layer_id": 1,
+        "layer_id": 0,
         "item_type": "layer",
     }
 ]

--- a/transportation-data-publishing/config/knack/config.py
+++ b/transportation-data-publishing/config/knack/config.py
@@ -562,18 +562,6 @@ SIGNS_AGOL = [
     # Order of config elements matters! Work orders must be processed before
     # speccs, materials, etc because work orders are the parent record.
     {
-        "name": "work_orders_signs",
-        "scene": "scene_1249",
-        "view": "view_3107",
-        "ref_obj": ["object_176"],
-        "modified_date_field_id": "field_3206",
-        "modified_date_field": "MODIFIED_DATE",
-        "primary_key": "ATD_WORK_ORDER_ID",
-        "service_id": "8e97ddf6f9bd4d26a7486b7ee40f7cce",
-        "layer_id": 2,  # note that this service id is actually 3, but this identifies the table #. not sure where this is exposed or documented. trial and error...
-        "item_type": "table",
-    },
-    {
         # there is no AGOL feature service for sign locations, instead
         # we merge location attributes to each work_orders_signs_asset_spec_actuals
         "name": "work_order_signs_locations",
@@ -587,6 +575,18 @@ SIGNS_AGOL = [
         "service_id": None,
         "layer_id": None,
         "item_type": None,
+    },
+    {
+        "name": "work_orders_signs",
+        "scene": "scene_1249",
+        "view": "view_3107",
+        "ref_obj": ["object_176"],
+        "modified_date_field_id": "field_3206",
+        "modified_date_field": "MODIFIED_DATE",
+        "primary_key": "ATD_WORK_ORDER_ID",
+        "service_id": "8e97ddf6f9bd4d26a7486b7ee40f7cce",
+        "layer_id": 2,  # note that this service id is actually 3, but this identifies the table #. not sure where this is exposed or documented. trial and error...
+        "item_type": "layer",
     },
     {
         "name": "work_orders_signs_asset_spec_actuals",

--- a/transportation-data-publishing/config/knack/config.py
+++ b/transportation-data-publishing/config/knack/config.py
@@ -586,7 +586,7 @@ SIGNS_AGOL = {
         "modified_date_field": "MODIFIED_DATE",
         "primary_key": "ATD_WORK_ORDER_ID",
         "service_id": "8e97ddf6f9bd4d26a7486b7ee40f7cce",
-        "layer_id": 2,  # note that this service id is actually 3, but this identifies the table #. not sure where this is exposed or documented. trial and error...
+        "layer_id": 1,  # note that this service id is actually 3, but this identifies the table #. not sure where this is exposed or documented. trial and error...
         "item_type": "layer",
     },
     "work_orders_signs_asset_spec_actuals" : {

--- a/transportation-data-publishing/config/knack/config.py
+++ b/transportation-data-publishing/config/knack/config.py
@@ -557,6 +557,38 @@ MARKINGS_AGOL = [
     },
 ]
 
+SIGNS_AGOL = [
+    # Knack and AGOL source object defintions.
+    # Order of config elements matters! Work orders must be processed before
+    # speccs, materials, etc because work orders are the parent record.
+    {
+        # there is no AGOL feature service for sign locations, instead
+        # we merge location attributes to each work_orders_signs_asset_spec_actuals
+        "name": "work_order_signs_locations",
+        "scene": "scene_1249",
+        "view": "view_3105",
+        "ref_obj": ["object_177", "object_176"],
+        "modified_date_field_id": "field_3383",
+        "modified_date_field": "MODIFIED_DATE",
+        "primary_key": "LOCATION_ID",
+        "geometry_field_name" : "SIGNS_LOCATION",
+        "service_id": None, 
+        "layer_id": None,
+        "item_type": None,
+    },
+    {
+        "name": "work_orders_signs_asset_spec_actuals",
+        "scene": "scene_1249",
+        "view": "view_3106",
+        "ref_obj": ["object_181", "object_178"],
+        "modified_date_field_id": "field_3365",
+        "modified_date_field": "MODIFIED_DATE",
+        "primary_key": "SPECIFICATION_ID",
+        "service_id": "8e97ddf6f9bd4d26a7486b7ee40f7cce",
+        "layer_id": 1,
+        "item_type": "layer",
+    }
+]
 
 SECONDARY_SIGNALS_UPDATER = {
     "update_field": "field_1329",

--- a/transportation-data-publishing/data_tracker/markings_agol.py
+++ b/transportation-data-publishing/data_tracker/markings_agol.py
@@ -30,7 +30,11 @@ def remove_empty_strings(records):
 def remove_empty_strings(records):
     new_records = []
     for record in records:
-        new_record = { key : record[key] for key in record.keys() if not (type(record[key]) == str and not record[key]) }
+        new_record = {
+            key: record[key]
+            for key in record.keys()
+            if not (type(record[key]) == str and not record[key])
+        }
         new_records.append(new_record)
     return new_records
 
@@ -229,8 +233,10 @@ def main():
                 records, in_fieldname="ATTACHMENT", out_fieldname="ATTACHMENT_URL"
             )
 
-        records = remove_empty_strings(records) # AGOL has unexepected handling of empty values
-        
+        records = remove_empty_strings(
+            records
+        )  # AGOL has unexepected handling of empty values
+
         update_layer = agolutil.get_item(
             auth=AGOL_CREDENTIALS,
             service_id=cfg["service_id"],

--- a/transportation-data-publishing/data_tracker/markings_agol.py
+++ b/transportation-data-publishing/data_tracker/markings_agol.py
@@ -1,37 +1,18 @@
 # Publish pavement markings work orders to ArcGIS Online
-import copy
 import pdb
 import traceback
 
-import agolutil
-import argutil
 import arrow
-import datautil
-import emailutil
-import knackutil
 import knackpy
 
 import _setpath
 from config.secrets import *
 from config.knack.config import MARKINGS_AGOL as config
 
-
-# we use this global to store wo geometries so they can be accessed
-# when fetching geometries for jobs. it aint pretty, but is it really so bad?
-work_order_geometries = None
-
-
-def get_paths_from_work_orders(
-    records, match_field="ATD_WORK_ORDER_ID", output_field="paths"
-):
-    # copy work order geometries from work order to child jobs
-    for record in records:
-        for wo in work_order_geometries:
-            if record[match_field] == wo[match_field]:
-                record[output_field] = wo[output_field]
-                continue
-
-    return records
+import agolutil
+import argutil
+import datautil
+import knackutil
 
 
 def remove_empty_strings(records):
@@ -148,7 +129,7 @@ def knackpy_wrapper(cfg, auth, obj=None, filters=None):
         app_id=auth["app_id"],
         api_key=auth["api_key"],
         filters=filters,
-        page_limit=1000000,
+        page_limit=10000,
     )
 
 
@@ -189,7 +170,6 @@ def main():
     we receive it.
     """
     for cfg in config:
-        print(cfg["name"])
         filters = knackutil.date_filter_on_or_after(
             last_run_date, cfg["modified_date_field_id"]
         )
@@ -210,15 +190,22 @@ def main():
 
         records = kn.data
 
-        if cfg.get("name") == "markings_work_orders":
-            #  markings work order geometries are retrieved from AGOL
+        if cfg.get("geometry_service_id"):
+            #  dataset has geomteries to be retrieved from another dataset
+            if cfg.get("multi_source_geometry"):
+                source_ids = datautil.unique_from_list_field(
+                    records, list_field=cfg["geometry_record_id_field"]
+                )
 
-            # reduce to unique segment ids from all records
-            segment_ids = datautil.unique_from_list_field(
-                records, list_field=cfg["geometry_record_id_field"]
-            )
+            else:
+                source_ids = datautil.get_values(
+                    records, cfg["geometry_record_id_field"]
+                )
 
-            if segment_ids:
+            where_ids = ", ".join(f"'{x}'" for x in source_ids)
+
+            if where_ids:
+                where = "{} in ({})".format(cfg["geometry_record_id_field"], where_ids)
 
                 geometry_layer = agolutil.get_item(
                     auth=AGOL_CREDENTIALS,
@@ -226,46 +213,20 @@ def main():
                     layer_id=cfg["geometry_layer_id"],
                 )
 
-                source_geometries_all = []
+                source_geometries = geometry_layer.query(
+                    where=where, outFields=cfg["geometry_record_id_field"]
+                )
 
-                chunksize = 200
-
-                for i in range(0, len(segment_ids), chunksize):
-                    # fetch agol source geometries in chunks
-
-                    print(f"Chunk {i}-{i+chunksize}")
-                    where_ids = ", ".join(
-                        f"'{x}'" for x in segment_ids[i : i + chunksize]
+                if not source_geometries:
+                    raise Exception(
+                        "No features returned from source geometry layer query"
                     )
-
-                    if where_ids:
-                        where = "{} in ({})".format(
-                            cfg["geometry_record_id_field"], where_ids
-                        )
-
-                        source_geometries_chunk = geometry_layer.query(
-                            where=where, outFields=cfg["geometry_record_id_field"]
-                        )
-
-                        if not source_geometries_chunk:
-                            raise Exception(
-                                "No features returned from source geometry layer query"
-                            )
-
-                        source_geometries_all.extend(source_geometries_chunk)
 
                 records = append_paths(
                     kn.data,
-                    source_geometries_all,
+                    source_geometries,
                     path_id_field=cfg["geometry_record_id_field"],
                 )
-
-                global work_order_geometries
-                work_order_geometries = copy.deepcopy(records)
-
-        elif cfg.get("name") == "markings_jobs":
-            # get data from markings records
-            records = get_paths_from_work_orders(records)
 
         if cfg.get("extract_attachment_url"):
             records = knackutil.attachment_url(
@@ -305,7 +266,6 @@ def main():
             agolutil.handle_response(res)
 
         for i in range(0, len(records), 1000):
-            # insert agol features in chunks
             adds = agolutil.feature_collection(
                 records[i : i + 1000], spatial_ref=102739
             )

--- a/transportation-data-publishing/data_tracker/markings_agol.py
+++ b/transportation-data-publishing/data_tracker/markings_agol.py
@@ -1,18 +1,37 @@
 # Publish pavement markings work orders to ArcGIS Online
+import copy
 import pdb
 import traceback
 
+import agolutil
+import argutil
 import arrow
+import datautil
+import emailutil
+import knackutil
 import knackpy
 
 import _setpath
 from config.secrets import *
 from config.knack.config import MARKINGS_AGOL as config
 
-import agolutil
-import argutil
-import datautil
-import knackutil
+
+# we use this global to store wo geometries so they can be accessed
+# when fetching geometries for jobs. it aint pretty, but is it really so bad?
+work_order_geometries = None
+
+
+def get_paths_from_work_orders(
+    records, match_field="ATD_WORK_ORDER_ID", output_field="paths"
+):
+    # copy work order geometries from work order to child jobs
+    for record in records:
+        for wo in work_order_geometries:
+            if record[match_field] == wo[match_field]:
+                record[output_field] = wo[output_field]
+                continue
+
+    return records
 
 
 def remove_empty_strings(records):
@@ -129,7 +148,7 @@ def knackpy_wrapper(cfg, auth, obj=None, filters=None):
         app_id=auth["app_id"],
         api_key=auth["api_key"],
         filters=filters,
-        page_limit=10000,
+        page_limit=1000000,
     )
 
 
@@ -170,6 +189,7 @@ def main():
     we receive it.
     """
     for cfg in config:
+        print(cfg["name"])
         filters = knackutil.date_filter_on_or_after(
             last_run_date, cfg["modified_date_field_id"]
         )
@@ -190,22 +210,15 @@ def main():
 
         records = kn.data
 
-        if cfg.get("geometry_service_id"):
-            #  dataset has geomteries to be retrieved from another dataset
-            if cfg.get("multi_source_geometry"):
-                source_ids = datautil.unique_from_list_field(
-                    records, list_field=cfg["geometry_record_id_field"]
-                )
+        if cfg.get("name") == "markings_work_orders":
+            #  markings work order geometries are retrieved from AGOL
 
-            else:
-                source_ids = datautil.get_values(
-                    records, cfg["geometry_record_id_field"]
-                )
+            # reduce to unique segment ids from all records
+            segment_ids = datautil.unique_from_list_field(
+                records, list_field=cfg["geometry_record_id_field"]
+            )
 
-            where_ids = ", ".join(f"'{x}'" for x in source_ids)
-
-            if where_ids:
-                where = "{} in ({})".format(cfg["geometry_record_id_field"], where_ids)
+            if segment_ids:
 
                 geometry_layer = agolutil.get_item(
                     auth=AGOL_CREDENTIALS,
@@ -213,20 +226,46 @@ def main():
                     layer_id=cfg["geometry_layer_id"],
                 )
 
-                source_geometries = geometry_layer.query(
-                    where=where, outFields=cfg["geometry_record_id_field"]
-                )
+                source_geometries_all = []
 
-                if not source_geometries:
-                    raise Exception(
-                        "No features returned from source geometry layer query"
+                chunksize = 200
+
+                for i in range(0, len(segment_ids), chunksize):
+                    # fetch agol source geometries in chunks
+
+                    print(f"Chunk {i}-{i+chunksize}")
+                    where_ids = ", ".join(
+                        f"'{x}'" for x in segment_ids[i : i + chunksize]
                     )
+
+                    if where_ids:
+                        where = "{} in ({})".format(
+                            cfg["geometry_record_id_field"], where_ids
+                        )
+
+                        source_geometries_chunk = geometry_layer.query(
+                            where=where, outFields=cfg["geometry_record_id_field"]
+                        )
+
+                        if not source_geometries_chunk:
+                            raise Exception(
+                                "No features returned from source geometry layer query"
+                            )
+
+                        source_geometries_all.extend(source_geometries_chunk)
 
                 records = append_paths(
                     kn.data,
-                    source_geometries,
+                    source_geometries_all,
                     path_id_field=cfg["geometry_record_id_field"],
                 )
+
+                global work_order_geometries
+                work_order_geometries = copy.deepcopy(records)
+
+        elif cfg.get("name") == "markings_jobs":
+            # get data from markings records
+            records = get_paths_from_work_orders(records)
 
         if cfg.get("extract_attachment_url"):
             records = knackutil.attachment_url(
@@ -266,6 +305,7 @@ def main():
             agolutil.handle_response(res)
 
         for i in range(0, len(records), 1000):
+            # insert agol features in chunks
             adds = agolutil.feature_collection(
                 records[i : i + 1000], spatial_ref=102739
             )

--- a/transportation-data-publishing/data_tracker/signs_agol.py
+++ b/transportation-data-publishing/data_tracker/signs_agol.py
@@ -149,7 +149,8 @@ def knackpy_wrapper(cfg, auth, obj=None, filters=None):
         app_id=auth["app_id"],
         api_key=auth["api_key"],
         filters=filters,
-        page_limit=1000000,
+        page_limit=1,
+        rows_per_page=10
     )
 
 
@@ -252,11 +253,9 @@ def main():
             #             else:
             #                 continue
             #
-            # TODO: remove this string truncation after feature sercice is patched
-            for record in records:
-                for key in record.keys():
-                    if key in ["CREATED_BY", "MODIFIED_BY"]:
-                        record[key] = record[key][:8]
+
+        
+        if cfg["name"] == "work_orders_signs_asset_spec_actuals":
 
         update_layer = agolutil.get_item(
             auth=AGOL_CREDENTIALS,

--- a/transportation-data-publishing/data_tracker/signs_agol.py
+++ b/transportation-data-publishing/data_tracker/signs_agol.py
@@ -1,0 +1,227 @@
+# Publish pavement markings work orders to ArcGIS Online
+import copy
+import pdb
+import traceback
+
+import agolutil
+import argutil
+import arrow
+import datautil
+import emailutil
+import knackutil
+import knackpy
+
+import _setpath
+from config.secrets import *
+from config.knack.config import SIGNS_AGOL as config
+
+
+
+"""
+get locations
+get specs
+merge them
+get work orders
+get attachments
+get materials
+
+"""
+
+def parse_geometry(record, geometry_field_name):
+    """
+    Extract lat/lon from knack location record.
+    """
+    lat_field = f"{geometry_field_name}_latitude"
+    lon_field = f"{geometry_field_name}_longitude"
+    return record.get(lon_field), record.get(lat_field)
+
+
+def process_locations(records, geometry_field_name, primary_key, wo_id_field="ATD_WORK_ORDER_ID"):
+    """
+    Construct a dictionary of select location attributes which will
+    be joined to spec actual records.
+
+    Parameters
+    ----------
+    records : list (required)
+        The source location records retrieved from Knack.
+    geometry_field_name : string (required)
+        The field name in the location records that contains the location data. 
+    primary_key : string (required)
+        The field which uniquely identifies each location record.
+    wo_id_field : string (required)
+        The field which identifies the parent work order record.
+
+    Returns
+    -------
+    dict of location record dicts
+
+    """
+    locations = {}
+
+    for record in records:
+        location = {}
+        id_ = record.get(primary_key)
+        wo_id = record.get(wo_id_field)
+        x, y = parse_geometry(record, geometry_field_name)
+        locations[id_] = {wo_id_field: wo_id, "x" : x, "y" : y}
+
+    pdb.set_trace()
+    return locations
+
+
+def filter_by_date(data, date_field, compare_date):
+    """Summary
+    
+    Args:
+        data (TYPE): Description
+        date_field (TYPE): Description
+        compare_date (TYPE): Description
+    
+    Returns:
+        TYPE: Description
+    """
+    return [record for record in data if record[date_field] >= compare_date]
+
+
+def knackpy_wrapper(cfg, auth, obj=None, filters=None):
+    """Summary
+    
+    Args:
+        cfg (TYPE): Description
+        auth (TYPE): Description
+        obj (None, optional): Description
+        filters (None, optional): Description
+    
+    Returns:
+        TYPE: Description
+    """
+    return knackpy.Knack(
+        obj=obj,
+        scene=cfg["scene"],
+        view=cfg["view"],
+        ref_obj=cfg["ref_obj"],
+        app_id=auth["app_id"],
+        api_key=auth["api_key"],
+        filters=filters,
+        page_limit=1,
+        rows_per_page=10
+    )
+
+
+def cli_args():
+
+    parser = argutil.get_parser(
+        "signs_agol.py",
+        "Publish Signs Work Order Data to ArcGIS Online",
+        "app_name",
+        "--replace",
+        "--last_run_date",
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+
+    args = cli_args()
+
+    auth = KNACK_CREDENTIALS[args.app_name]
+
+    records_processed = 0
+
+    last_run_date = args.last_run_date
+
+    if not last_run_date or args.replace:
+        # replace dataset by setting the last run date to a long, long time ago
+        # the arrow package needs a specific date and timeformat
+        last_run_date = "1970-01-01"
+    """
+    We include a filter in our API call to limit to records which have
+    been modified on or after the date the last time this job ran
+    successfully. The Knack API supports filter requests by date only
+    (not time), so we must apply an additional filter on the data after
+    we receive it.
+    """
+    for cfg in config:
+        
+        print(cfg["name"])
+
+        filters = knackutil.date_filter_on_or_after(
+            last_run_date, cfg["modified_date_field_id"]
+        )
+
+        kn = knackpy_wrapper(cfg, auth, filters=filters)
+
+        if kn.data:
+            # Filter data for records that have been modifed after the last
+            # job run (see comment above)
+            last_run_timestamp = arrow.get(last_run_date).timestamp * 1000
+            kn.data = filter_by_date(
+                kn.data, cfg["modified_date_field"], last_run_timestamp
+            )
+
+        if not kn.data:
+            records_processed += 0
+            continue
+
+        records = kn.data
+
+        if cfg["name"] == "work_order_signs_locations":
+            # location data from this object is merged to asset spec records
+            process_locations(kn.data, cfg["geometry_field_name"], cfg["primary_key"])
+            print("hi")
+
+        if cfg.get("extract_attachment_url"):
+            records = knackutil.attachment_url(
+                records, in_fieldname="ATTACHMENT", out_fieldname="ATTACHMENT_URL"
+            )
+
+        records = remove_empty_strings(
+            records
+        )  # AGOL has unexepected handling of empty values
+
+        # update_layer = agolutil.get_item(
+        #     auth=AGOL_CREDENTIALS,
+        #     service_id=cfg["service_id"],
+        #     layer_id=cfg["layer_id"],
+        #     item_type=cfg["item_type"],
+        # )
+
+        # if args.replace:
+        #     res = update_layer.delete_features(where="1=1")
+        #     agolutil.handle_response(res)
+
+        # else:
+        #     """
+        #     Delete objects by primary key. ArcGIS api does not currently support
+        #     an upsert method, although the Python api defines one via the
+        #     layer.append method, it is apparently still under development. So our
+        #     "upsert" consists of a delete by primary key then add.
+        #     """
+        #     primary_key = cfg.get("primary_key")
+
+        #     delete_ids = [record.get(primary_key) for record in records]
+        #     delete_ids = ", ".join(f"'{x}'" for x in delete_ids)
+
+        #     #  generate a SQL-like where statement to identify records for deletion
+        #     where = "{} in ({})".format(primary_key, delete_ids)
+        #     res = update_layer.delete_features(where=where)
+        #     agolutil.handle_response(res)
+
+        # for i in range(0, len(records), 1000):
+        #     # insert agol features in chunks
+        #     adds = agolutil.feature_collection(
+        #         records[i : i + 1000], spatial_ref=102739
+        #     )
+        #     res = update_layer.edit_features(adds=adds)
+        #     agolutil.handle_response(res)
+        #     records_processed += len(adds)
+
+    return records_processed
+
+
+if __name__ == "__main__":
+    main()

--- a/transportation-data-publishing/data_tracker/signs_agol.py
+++ b/transportation-data-publishing/data_tracker/signs_agol.py
@@ -23,9 +23,10 @@ from config.knack.config import SIGNS_AGOL as config
 -[ ] post specs to agol: in progress
     - handle photos from location records and post to agol
 -[ ] get work orders + post
+    - ready except need to convert to multipoint layer and do geomtries
 -[ ] get attachments + post
 -[ ] get materials + post
-
+- check all columns popualting
 """
 
 

--- a/transportation-data-publishing/data_tracker/signs_agol.py
+++ b/transportation-data-publishing/data_tracker/signs_agol.py
@@ -229,12 +229,12 @@ def main():
             layer_id=cfg["layer_id"],
             item_type=cfg["item_type"],
         )
-
+        
+        if args.replace:
+            res = update_layer.delete_features(where="1=1")
+            agolutil.handle_response(res)
+            
         pdb.set_trace()
-        # if args.replace:
-        #     res = update_layer.delete_features(where="1=1")
-        #     agolutil.handle_response(res)
-
         # else:
         #     """
         #     Delete objects by primary key. ArcGIS api does not currently support

--- a/transportation-data-publishing/open_data/knack_data_pub.py
+++ b/transportation-data-publishing/open_data/knack_data_pub.py
@@ -325,7 +325,11 @@ def main():
     ]
 
     if args.destination[0] == "socrata":
-        pub = socrata_pub(kn.data, cfg_dataset, args.replace, date_fields=date_fields)
+        try:
+            pub = socrata_pub(kn.data, cfg_dataset, args.replace, date_fields=date_fields)
+        except:
+            import pdb
+            pdb.set_trace()
 
     if args.destination[0] == "agol":
         pub = agol_pub(kn.data, cfg_dataset, args.replace)


### PR DESCRIPTION
This script publishes signs work orders from our asset management application (Knack) to a [feature service](https://austin.maps.arcgis.com/home/item.html?id=93e29b23c39b4110ab0bbefde79b4063) on ArcGIS Online.