### PR TITLE
Integrate Work Orders w/ Finance & Purchasing System

### DIFF
--- a/transportation-data-publishing/config/knack/config.py
+++ b/transportation-data-publishing/config/knack/config.py
@@ -374,7 +374,7 @@ cfg = {
         "obj": None,
         "scene": "scene_683",
         "view": "view_1829",
-        "ref_obj": ["object_31", "object_11"],
+        "ref_obj": ["object_31", "object_11", "object_89"],
         "socrata_resource_id": "hst3-hxcz",
         "status_field": "WORK_ORDER_STATUS",
         "location_fields": {

--- a/transportation-data-publishing/finance_admin/get_work_orders.py
+++ b/transportation-data-publishing/finance_admin/get_work_orders.py
@@ -2,14 +2,9 @@
 Get AMD work orders from the Data Tracker and upsert them
 to the Finance & Purchasing System so that they can be incorporated
 w/ inventory requests.
-
-TODO
-- todo: enforce unique work_order_id in finance and admin to prevent dupes
-- get all modified work orders
-- convert connection objects, to short text if needed
-- upsert them to f&p
 """
 from pprint import pprint as print
+import pdb
 
 import argutil
 import datautil
@@ -20,68 +15,52 @@ import _setpath
 from config.secrets import KNACK_CREDENTIALS
 from config.knack.config import cfg
 
+
 FINANCE_ADMIN_CONFIG = {
-    "data_tracker_finance_record_id_field_name" : "FINANCE_ADMIN_RECORD_ID", # column in data tracker work orders that contains the record id of the work order in the finance/admin system. if it exists.
-    "data_tracker_finance_record_id_field_id" : "field_3424",
-    "work_orders_object" : "object_33" 
+    "data_tracker_finance_record_id_field_name": "FINANCE_ADMIN_RECORD_ID",  # column in data tracker work orders that contains the record id of the work order in the finance/admin system. if it exists.
+    "data_tracker_finance_record_id_field_id": "field_3424",  # data tracker work orders that contains the record id of the work order in the finance/admin system. if it exists
+    "work_orders_object": "object_33",  # This is the work orders objet in the finance & purchasing system
+    "finance_data_tracker_record_id_field_id": "field_758",  # field ID in Finance & Purchasing system that contains the Knack record ID of the matching record in the Data Tracker
 }
 
 FIELDMAP = {
-    "LOCATION_NAME" : "field_722",
-    "WORK_NEEDED" : "field_723",
-    "TECHNICIAN_LEAD" : "field_724",
-    "TECHNICIAN_SUPPORT" : "field_725",
-    "SIGNAL_ID" : "field_726",
-    "SCHOOL_ZONE" : "field_727",
-    "ATD_WORK_ORDER_ID" : "field_721",
-    "WORK_ORDER_STATUS" : "field_728",
+    "CREATED_DATE": "field_757",
+    "LOCATION_NAME": "field_722",
+    "WORK_NEEDED": "field_723",
+    "TECHNICIAN_LEAD": "field_724",
+    "TECHNICIAN_SUPPORT": "field_725",
+    "SIGNAL_ID": "field_726",
+    "SCHOOL_ZONE": "field_727",
+    "ATD_WORK_ORDER_ID": "field_721",
+    "WORK_ORDER_STATUS": "field_728",
+    "id": "field_758",  # the Data Tracker record ID stored in the Finance & Purchasing system in this field
+    "ZONE_NAME": "field_727",
+    FINANCE_ADMIN_CONFIG["data_tracker_finance_record_id_field_name"]: "id",
 }
 
-def build_data_tracker_payload(
-        finance_admin_record_id,
-        data_tracker_finance_record_id_field_id,
-        data_tracker_id
-    ):
 
-    
+def build_data_tracker_payload(
+    finance_admin_record_id, data_tracker_id, data_tracker_finance_record_id_field_id
+):
+
     # prepare a payload to update the data tracker work order with the finance_admin record id
     return {
         "id": data_tracker_id,
-        data_tracker_finance_record_id_field_id : finance_admin_record_id
+        data_tracker_finance_record_id_field_id: finance_admin_record_id,
     }
 
 
-def post_records(payload, auth, obj_key):
-    records_processed = 0
+def post_record(record, auth, obj_key, method):
 
-    for record in payload:
-        if record.get(FINANCE_ADMIN_CONFIG["data_tracker_finance_record_id_field_name"]):
-            # record already exists in finance system
-            method = "update"
-            
-        else:
-            method = "create"
+    res = knackpy.record(
+        record,
+        obj_key=obj_key,
+        app_id=auth["app_id"],
+        api_key=auth["api_key"],
+        method=method,
+    )
 
-        import pdb; pdb.set_trace()
-        # update/inset to finance
-        res = knackpy.record(
-            record,
-            obj_key=FINANCE_ADMIN_CONFIG["work_orders_object"],
-            app_id = auth["app_id"],
-            api_key = auth["api_key"],
-            method = method
-        )
-
-        import pdb; pdb.set_trace()
-
-        payload = build_data_tracker_payload(res[0]["id"], record["id"], FINANCE_ADMIN_CONFIG["data_tracker_finance_record_id_field_id"])
-
-        import pdb; pdb.set_trace()
-
-        res = update_data_tracker(payload)
-        records_processed +=1
-    
-    return records_processed
+    return res
 
 
 def knackpy_wrapper(cfg_dataset, auth, filters=None):
@@ -93,14 +72,14 @@ def knackpy_wrapper(cfg_dataset, auth, filters=None):
         app_id=auth["app_id"],
         api_key=auth["api_key"],
         filters=filters,
-        page_limit=1, #TODO repalce this with 1000
-        rows_per_page=10, #tODO remove this param
+        page_limit=3,
+        rows_per_page=1000,
     )
 
 
 def map_fields(list_of_dicts, fieldmap):
     mapped = []
-    
+
     for record in list_of_dicts:
         new_record = {}
 
@@ -126,16 +105,15 @@ def cli_args():
 
     return parsed
 
+
 def main():
     config_data_tracker = cfg["work_orders_signals"]
 
-    # config_finance_admin = cfg["config_finance_admin"]
-    
     args = cli_args()
 
     auth_data_tracker = KNACK_CREDENTIALS["data_tracker_prod"]
 
-    auth_finance_admin= KNACK_CREDENTIALS["finance_admin_prod"]
+    auth_finance_admin = KNACK_CREDENTIALS["finance_admin_prod"]
 
     last_run_date = args.last_run_date
 
@@ -144,30 +122,59 @@ def main():
         last_run_date = "1970-01-01"
 
     filters = knackutil.date_filter_on_or_after(
-        last_run_date,config_data_tracker["modified_date_field_id"]
+        last_run_date, config_data_tracker["modified_date_field_id"]
     )
 
-    # TODO: filter by status?
-
-    work_orders = knackpy_wrapper(config_data_tracker, auth_data_tracker, filters=filters)
+    # get work order data from Data Tracker
+    work_orders = knackpy_wrapper(
+        config_data_tracker, auth_data_tracker, filters=filters
+    )
 
     if not work_orders:
         return 0
 
+    # prepare payload for finace & purchasing system
     payload = map_fields(work_orders.data, FIELDMAP)
 
-    records_processed = post_records(payload, auth_finance_admin, FINANCE_ADMIN_CONFIG["work_orders_object"])
+    records_processed = 0
 
-    import pdb; pdb.set_trace()
+    for record in payload:
+
+        data_tracker_record_id = record.get(FIELDMAP["id"])
+
+        if record.get("id"):
+            method = "update"
+
+        else:
+            method = "create"
+
+        new_record = post_record(
+            record,
+            auth_finance_admin,
+            FINANCE_ADMIN_CONFIG["work_orders_object"],
+            method,
+        )
+
+        if method == "create":
+            # update data tracker with record id of matching record in finance system, if it doens't already exist
+            data_tracker_update = build_data_tracker_payload(
+                new_record["id"],
+                data_tracker_record_id,
+                FINANCE_ADMIN_CONFIG["data_tracker_finance_record_id_field_id"],
+            )
+
+            res = post_record(
+                data_tracker_update,
+                auth_data_tracker,
+                config_data_tracker["ref_obj"][0],
+                "update",
+            )
+
+        records_processed += 1
+        print(records_processed)
 
     return records_processed
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     main()
-    
-
-
-
-
-
-

--- a/transportation-data-publishing/finance_admin/get_work_orders.py
+++ b/transportation-data-publishing/finance_admin/get_work_orders.py
@@ -1,0 +1,126 @@
+"""
+Get AMD work orders from the Data Tracker and upsert them
+to the Finance & Purchasing System so that they can be incorporated
+w/ inventory requests.
+
+TODO
+- todo: enforce unique work_order_id in finance and admin to prevent dupes
+- get all modified work orders
+- convert connection objects, to short text if needed
+- upsert them to f&p
+"""
+from pprint import pprint as print
+
+import argutil
+import datautil
+import knackpy
+import knackutil
+
+import _setpath
+from config.secrets import KNACK_CREDENTIALS
+from config.knack.config import cfg
+
+FINANCE_ADMIN_CONFIG = {
+    "data_tracker_finance_record_id_field" : "FINANCE_ADMIN_RECORD_ID" # column in data tracker work orders that contains the record id of the work order in the finance/admin system. if it exists.
+}
+
+FIELDMAP = {}
+
+
+def post_records(payload, config):
+    records_processed = 0
+
+    for record in payload:
+        if payload.get(FINANCE_ADMIN_CONFIG["data_tracker_finance_record_id_field"]):
+            # record already exists in finance system
+            method = "update"
+            
+        else:
+            method = "create"
+
+        res = upload_to_finance(record)
+        payload = build_data_tracker_payload(record["id"])
+        res = update_data_tracker(payload)
+        records_processed +=1
+    
+    return records_processed
+
+
+def knackpy_wrapper(cfg_dataset, auth, filters=None):
+    return knackpy.Knack(
+        obj=cfg_dataset["obj"],
+        scene=cfg_dataset["scene"],
+        view=cfg_dataset["view"],
+        ref_obj=cfg_dataset["ref_obj"],
+        app_id=auth["app_id"],
+        api_key=auth["api_key"],
+        filters=filters,
+        page_limit=1, #TODO repalce this with 1000
+        rows_per_page=10, #tODO remove this param
+    )
+
+
+def map_fields(list_of_dicts, fieldmap):
+    mapped = []
+
+    return mapped
+
+
+def cli_args():
+
+    parser = argutil.get_parser(
+        "get_work_orders.py",
+        "Get AMD work orders and upload to Finance & Purchasing system",
+        "--replace",
+        "--last_run_date",
+    )
+
+    parsed = parser.parse_args()
+
+    return parsed
+
+def main():
+    config_data_tracker = cfg["work_orders_signals"]
+
+    # config_finance_admin = cfg["config_finance_admin"]
+    
+    args = cli_args()
+
+    auth_data_tracker = KNACK_CREDENTIALS["data_tracker_prod"]
+
+    auth_finance_admin= KNACK_CREDENTIALS["finance_admin_prod"]
+
+    last_run_date = args.last_run_date
+
+    if not last_run_date or args.replace:
+        # replace dataset by setting the last run date to a long, long time ago
+        last_run_date = "1970-01-01"
+
+    filters = knackutil.date_filter_on_or_after(
+        last_run_date,config_data_tracker["modified_date_field_id"]
+    )
+
+    # TODO: filter by status?
+
+    work_orders = knackpy_wrapper(config_data_tracker, auth_data_tracker, filters=filters)
+
+    if not work_orders:
+        return 0
+
+    import pdb; pdb.set_trace()
+
+    payload = map_fields(work_orders.data_raw, FIELDMAP)
+
+    records_processed = post_records(payload, auth_finance_admin)
+
+    return records_processed
+
+if __name__=="__main__":
+    main()
+    
+
+
+
+
+
+


### PR DESCRIPTION
Fixes [#833](https://github.com/cityofaustin/atd-data-tech/issues/833). This script downloads recently modified work orders from the Data Tracker and upserts those records to the Finance & Purchasing system. It also updates the Data Tracker with the Knack record ID of the work order record in the Finance & Purchasing system. It is meant to be deployed and run on a high-frequency cron job, in which it checks for only recently modified records.