### PR TITLE
Add Delay Between Outbound Messages to ESB

### DIFF
--- a/transportation-data-publishing/config/esb/esb_csr_template_signals.xml
+++ b/transportation-data-publishing/config/esb/esb_csr_template_signals.xml
@@ -18,7 +18,7 @@
              <sr_number>{SR_NUMBER}</sr_number>
              <issue_status_code>{ISSUE_STATUS_CODE_SNAPSHOT}</issue_status_code>
              <activity_details>{TMC_ACTIVITY_DETAILS}</activity_details><!--   concatenation of activity type and details -->
-             <activity_date>{TMC_ACTIVITY_DATETIME}</activity_date>
+             <activity_date>{TMC_ACTIVITY_DATETIME_UNIX_MILLS}</activity_date>
           </csr>
         </data>
       </acc:submitKnack>

--- a/transportation-data-publishing/config/esb/esb_csr_template_signals.xml
+++ b/transportation-data-publishing/config/esb/esb_csr_template_signals.xml
@@ -18,7 +18,7 @@
              <sr_number>{SR_NUMBER}</sr_number>
              <issue_status_code>{ISSUE_STATUS_CODE_SNAPSHOT}</issue_status_code>
              <activity_details>{TMC_ACTIVITY_DETAILS}</activity_details><!--   concatenation of activity type and details -->
-             <activity_date>{TMC_ACTIVITY_DATETIME_UNIX_MILLS}</activity_date>
+             <activity_date>{TMC_ACTIVITY_DATETIME}</activity_date>
           </csr>
         </data>
       </acc:submitKnack>

--- a/transportation-data-publishing/data_tracker/esb_xml_gen.py
+++ b/transportation-data-publishing/data_tracker/esb_xml_gen.py
@@ -181,11 +181,6 @@ def main():
         if kn.fields[f]["type"] in ["date_time", "date"]
     ]
 
-    # TODO - move to config. This is a text formula field that we use to extract
-    # the specific seconds of the activity datetime. seconds are
-    # rounded in the standard knack date fields
-    date_fields_kn.append("TMC_ACTIVITY_DATETIME_UNIX_MILLS")
-
     kn.data = datautil.mills_to_iso(kn.data, date_fields_kn)
 
     for record in kn.data:

--- a/transportation-data-publishing/data_tracker/esb_xml_gen.py
+++ b/transportation-data-publishing/data_tracker/esb_xml_gen.py
@@ -180,6 +180,12 @@ def main():
         for f in kn.fields
         if kn.fields[f]["type"] in ["date_time", "date"]
     ]
+
+    # TODO - move to config. This is a text formula field that we use to extract
+    # the specific seconds of the activity datetime. seconds are
+    # rounded in the standard knack date fields
+    date_fields_kn.append("TMC_ACTIVITY_DATETIME_UNIX_MILLS")
+
     kn.data = datautil.mills_to_iso(kn.data, date_fields_kn)
 
     for record in kn.data:

--- a/transportation-data-publishing/data_tracker/esb_xml_send.py
+++ b/transportation-data-publishing/data_tracker/esb_xml_send.py
@@ -4,6 +4,7 @@ via Enterprise Service Bus
 """
 import os
 import pdb
+import time
 
 import arrow
 import knackpy
@@ -202,6 +203,11 @@ def main():
         )
 
         move_file(inpath, outpath, filename)
+
+        # wait a few seconds between between message send
+        # hoping to ensure messages are processed chronologically
+        # by 311
+        time.sleep(10)
 
     return len(files)
 


### PR DESCRIPTION
Fixes [#81](https://github.com/cityofaustin/atd-knack-data-tracker/issues/81).

Wait 10 seconds between XML message publications to the ESB.

We're hoping this causes the activities to be processed by CSR chronologically. 